### PR TITLE
Add support for null filter

### DIFF
--- a/DevExtreme/FilterHelper.php
+++ b/DevExtreme/FilterHelper.php
@@ -88,6 +88,20 @@ class FilterHelper {
                     $clause = "";
                 }
             }
+            
+            if(is_null($val)){
+                $val = "null";
+
+                switch ($clause){
+                    case "=":
+                        $clause = "IS";
+                        break;
+                    case "<>":
+                        $clause = "IS NOT";
+                        break;
+                }
+            }
+            
             $result = sprintf($pattern, $fieldName, $clause, $val);
         }
         return $result;

--- a/DevExtreme/Utils.php
+++ b/DevExtreme/Utils.php
@@ -29,6 +29,11 @@ class Utils {
         if (!$isFieldName) {
            $value = self::_ConvertDateTimeToMySQLValue($value);
         }
+        
+        if(is_null($value)){
+            return $value;
+        }
+        
         $resultPattern = $isFieldName ? "`%s`" : (is_bool($value) ? "%s" : "'%s'");
         $result = sprintf($resultPattern, is_bool($value) ? ($value ? "1" : "0") : strval($value));
         return $result;


### PR DESCRIPTION
Currently null is treated as empty string ('') due to the sprintf format and filtering for null values is not possible as the value to filter is '' and the clause is =/<> (which doesn't work in sql).

Modified the code to return early if null is detected and to transform the clause into IS/IS NOT and the value to "null"